### PR TITLE
enable go-card on darwin Mac OSX

### DIFF
--- a/smartcard/pcsc/winscard_wrapper_darwin.go
+++ b/smartcard/pcsc/winscard_wrapper_darwin.go
@@ -1,0 +1,226 @@
+// +build darwin
+
+package pcsc
+
+//#cgo CFLAGS: -framework PCSC
+//#cgo LDFLAGS: -framework PCSC
+//#include <PCSC/winscard.h>
+//#include <PCSC/wintypes.h>
+import "C"
+import (
+	"bytes"
+	"fmt"
+	"unsafe"
+)
+
+type readerState struct {
+	reader       uintptr
+	userData     uintptr
+	currentState uint32
+	eventState   uint32
+	atrLen       uint32
+	atr          [_MAX_ATR_SIZE]byte
+}
+
+type ReaderState struct {
+	Reader       string
+	UserData     uintptr
+	CurrentState uint32
+	EventState   uint32
+	AtrLen       uint32
+	Atr          [_MAX_ATR_SIZE]byte
+}
+
+type WinscardWrapper struct {
+	t0PCI uintptr
+	t1PCI uintptr
+}
+
+var theWrapper *WinscardWrapper = nil
+
+func Winscard() (*WinscardWrapper, error) {
+	if theWrapper != nil {
+		return theWrapper, nil
+	}
+	t0 := C.g_rgSCardT0Pci
+	t1 := C.g_rgSCardT1Pci
+	winscard := &WinscardWrapper{
+		t0PCI: uintptr(unsafe.Pointer(&t0)),
+		t1PCI: uintptr(unsafe.Pointer(&t1)),
+	}
+	return winscard, nil
+}
+
+func (ww *WinscardWrapper) T0PCI() uintptr {
+	return ww.t0PCI
+}
+
+func (ww *WinscardWrapper) T1PCI() uintptr {
+	return ww.t1PCI
+}
+
+func (ww *WinscardWrapper) stringToBytes(str string) []byte {
+	var buffer bytes.Buffer
+	buffer.WriteString(str)
+	buffer.WriteByte(0)
+	return buffer.Bytes()
+}
+
+func (ww *WinscardWrapper) EstablishContext() (uintptr, error) {
+
+	var hContext C.SCARDCONTEXT
+	rv := C.SCardEstablishContext(C.SCARD_SCOPE_SYSTEM, nil, nil, &hContext)
+
+	if rv != SCARD_S_SUCCESS {
+		return 0, fmt.Errorf("can't establish context: %s",
+			errorString(uint32(rv)))
+	}
+	return uintptr(hContext), nil
+}
+
+func (ww *WinscardWrapper) ReleaseContext(ctx uintptr) error {
+	rv := C.SCardReleaseContext(C.int(ctx))
+
+	if rv != SCARD_S_SUCCESS {
+		return fmt.Errorf("can't release context: %s",
+			errorString(uint32(rv)))
+	}
+	return nil
+}
+
+func (ww *WinscardWrapper) ListReaders(ctx uintptr) ([]string, error) {
+	var bufferSize C.DWORD
+	var rv C.LONG
+	readers := make([]string, 0, 3)
+	rv = C.SCardListReaders(C.int(ctx), nil, nil, &bufferSize)
+	if rv != SCARD_S_SUCCESS {
+		if uint64(rv) == SCARD_E_NO_READERS_AVAILABLE {
+			return readers, nil
+		}
+		return nil, fmt.Errorf("can't list readers: %s",
+			errorString(uint32(rv)))
+	}
+	buffer := make([]byte, bufferSize)
+	rv = C.SCardListReaders(C.int(ctx), nil, (*C.char)(unsafe.Pointer(&buffer[0])), &bufferSize)
+
+	if rv != SCARD_S_SUCCESS {
+		return nil, fmt.Errorf("can't list readers: %s",
+			errorString(uint32(rv)))
+	}
+	n := bytes.IndexByte(buffer, 0)
+	for n != 0 {
+		readers = append(readers, string(buffer[:n]))
+		buffer = buffer[n+1:]
+		n = bytes.IndexByte(buffer, 0)
+	}
+	return readers, nil
+}
+
+func (ww *WinscardWrapper) GetStatusChange(ctx uintptr, timeout uint32,
+	states []ReaderState) error {
+	_states := make([]readerState, len(states))
+	for i := 0; i < len(states); i++ {
+		var buffer bytes.Buffer
+		buffer.WriteString(states[i].Reader)
+		buffer.WriteByte(0)
+		_states[i].reader = uintptr(unsafe.Pointer(&buffer.Bytes()[0]))
+		_states[i].currentState = states[i].CurrentState
+	}
+	rv := C.SCardGetStatusChange(C.int(ctx), C.uint(timeout),
+		(C.LPSCARD_READERSTATE_A)(unsafe.Pointer(&_states[0])), C.uint(len(_states)))
+	if rv != SCARD_S_SUCCESS {
+		return fmt.Errorf("get status change failed: %s",
+			errorString(uint32(rv)))
+	}
+	for i := 0; i < len(states); i++ {
+		states[i].UserData = _states[i].userData
+		states[i].EventState = _states[i].eventState
+		states[i].AtrLen = _states[i].atrLen
+		states[i].Atr = _states[i].atr
+	}
+	return nil
+}
+
+func (ww *WinscardWrapper) GetStatusChangeAll(ctx uintptr, timeout uint32,
+	currentState uint32) ([]ReaderState, error) {
+	readerNames, err := ww.ListReaders(ctx)
+	if err != nil {
+		return nil, err
+	}
+	count := len(readerNames)
+	if count == 0 {
+		return nil, nil
+	}
+	states := make([]ReaderState, 1)
+	for i := 0; i < len(readerNames); i++ {
+		states[i].Reader = readerNames[i]
+		states[i].CurrentState = currentState
+	}
+	err = ww.GetStatusChange(ctx, SCARD_INFINITE, states)
+	if err != nil {
+		return nil, err
+	}
+	return states, nil
+}
+
+func (ww *WinscardWrapper) CardConnect(ctx uintptr, reader string) (
+	uintptr, uintptr, error) {
+	var card C.int
+	var activeProtocol C.uint
+	rv := C.SCardConnect(C.int(ctx), (*C.char)(unsafe.Pointer(&ww.stringToBytes(reader)[0])), C.SCARD_SHARE_SHARED,
+		C.SCARD_PROTOCOL_ANY, &card, &activeProtocol)
+	if rv != SCARD_S_SUCCESS {
+		return 0, 0, fmt.Errorf("can't connect to card: %s",
+			errorString(uint32(rv)))
+	}
+	return uintptr(card), uintptr(activeProtocol), nil
+}
+
+func (ww *WinscardWrapper) CardDisconnect(card uintptr) error {
+	rv := C.SCardDisconnect(C.int(card), SCARD_RESET_CARD)
+	if rv != SCARD_S_SUCCESS {
+		return fmt.Errorf("can't disconnect from card: %s",
+			errorString(uint32(rv)))
+	}
+	return nil
+}
+
+func (ww *WinscardWrapper) Transmit(card uintptr, sendPCI uintptr,
+	sendBuffer []byte, recvBuffer []byte) (uint32, error) {
+	received := C.uint(len(recvBuffer))
+	rv := C.SCardTransmit(C.int(card),
+		(*C.SCARD_IO_REQUEST)(unsafe.Pointer(sendPCI)),
+		(*C.uchar)(unsafe.Pointer(&sendBuffer[0])),
+		C.uint(len(sendBuffer)),
+		nil,
+		(*C.uchar)(unsafe.Pointer(&recvBuffer[0])),
+		&received)
+
+	if rv != SCARD_S_SUCCESS {
+		return 0, fmt.Errorf("transmission failed: %s",
+			errorString(uint32(rv)))
+	}
+
+	return uint32(received), nil
+}
+
+func (ww WinscardWrapper) GetAttrib(card uintptr, attr uint32) ([]byte, error) {
+	var size C.uint
+
+	rv := C.SCardGetAttrib(C.int(card), C.uint(attr),
+		nil, &size)
+	if rv != SCARD_S_SUCCESS {
+		return nil, fmt.Errorf("can't get attribute : %s",
+			errorString(uint32(rv)))
+	}
+	buffer := make([]byte, size)
+	rv = C.SCardGetAttrib(C.int(card),
+		C.uint(attr),
+		(*C.uchar)(unsafe.Pointer(&buffer[0])),
+		&size)
+	if rv != SCARD_S_SUCCESS {
+		return nil, fmt.Errorf("can't get attribute : %s",
+			errorString(uint32(rv)))
+	}
+	return buffer[:size], nil
+}

--- a/smartcard/smartcard_pcsclite.go
+++ b/smartcard/smartcard_pcsclite.go
@@ -1,159 +1,172 @@
 // +build !windows
+// +build !darwin
 
 package smartcard
 
 import (
-    "time"
-    "github.com/sf1/go-card/smartcard/pcsc"
+	"github.com/sf1/go-card/smartcard/pcsc"
+	"time"
 )
 
 // A smart card context is required to access readers and cards.
 type Context struct {
-    client *pcsc.PCSCLiteClient
-    ctxID uint32
+	client *pcsc.PCSCLiteClient
+	ctxID  uint32
 }
 
 // Establish smart card context.
 // This should be the first function to be called.
 func EstablishContext() (*Context, error) {
-    var err error
-    context := &Context{}
-    context.client, err = pcsc.PCSCLiteConnect()
-    if err != nil { return nil, err }
-    context.ctxID, err = context.client.EstablishContext()
-    return context, nil
+	var err error
+	context := &Context{}
+	context.client, err = pcsc.PCSCLiteConnect()
+	if err != nil {
+		return nil, err
+	}
+	context.ctxID, err = context.client.EstablishContext()
+	return context, nil
 }
 
 // Release resources associated with smart card context.
 func (ctx *Context) Release() error {
-    return ctx.client.ReleaseContext(ctx.ctxID)
+	return ctx.client.ReleaseContext(ctx.ctxID)
 }
 
 // List all smart card readers.
 func (ctx *Context) ListReaders() ([]*Reader, error) {
-    return ctx.listReaders(false)
+	return ctx.listReaders(false)
 }
 
 // List smart card readers with inserted cards.
 func (ctx *Context) ListReadersWithCard() ([]*Reader, error) {
-    return ctx.listReaders(true)
+	return ctx.listReaders(true)
 }
 
 func (ctx *Context) listReaders(withCard bool) ([]*Reader, error) {
-    readers, err := ctx.client.ListReaders()
-    if err != nil { return nil, err }
-    result := make([]*Reader, 0, len(readers))
-    for i := 0; i < len(readers); i++ {
-        if withCard {
-            if readers[i].IsCardPresent() {
-                result = append(result, &Reader{
-                    context: ctx, reader: *readers[i]})
-            }
-        } else {
-            result = append(result, &Reader{
-                context: ctx, reader: *readers[i]})
-        }
-    }
-    return result, nil
+	readers, err := ctx.client.ListReaders()
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*Reader, 0, len(readers))
+	for i := 0; i < len(readers); i++ {
+		if withCard {
+			if readers[i].IsCardPresent() {
+				result = append(result, &Reader{
+					context: ctx, reader: *readers[i]})
+			}
+		} else {
+			result = append(result, &Reader{
+				context: ctx, reader: *readers[i]})
+		}
+	}
+	return result, nil
 }
 
 // Block until a smart card is inserted into any reader.
 // Returns immediately if card already present.
 func (ctx *Context) WaitForCardPresent() (*Reader, error) {
-    var reader *Reader
-    for reader == nil {
-        count, err := ctx.client.SyncReaders()
-        if err != nil { return nil, err}
-        for i := uint32(0); i < count; i++ {
-            r := ctx.client.Readers()[i]
-            if r.IsCardPresent() {
-                reader = &Reader{context: ctx, reader: r}
-                break
-            }
-        }
-        if reader != nil {
-            break
-        }
-        time.Sleep(250*time.Millisecond)
-    }
-    return reader, nil
+	var reader *Reader
+	for reader == nil {
+		count, err := ctx.client.SyncReaders()
+		if err != nil {
+			return nil, err
+		}
+		for i := uint32(0); i < count; i++ {
+			r := ctx.client.Readers()[i]
+			if r.IsCardPresent() {
+				reader = &Reader{context: ctx, reader: r}
+				break
+			}
+		}
+		if reader != nil {
+			break
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	return reader, nil
 }
 
-// Smart card reader. 
+// Smart card reader.
 // Note that physical card readers with slots for multiple cards are
 // represented by one Reader instance per slot.
 type Reader struct {
-    context *Context
-    reader pcsc.Reader
+	context *Context
+	reader  pcsc.Reader
 }
 
 // Return name of card reader.
 func (r *Reader) Name() string {
-    return r.reader.Name()
+	return r.reader.Name()
 }
 
 // Check if card is present.
 func (r *Reader) IsCardPresent() bool {
-    count, err := r.context.client.SyncReaders()
-    if err != nil {
-        return false
-    }
-    readers := r.context.client.Readers()
-    for i := uint32(0); i < count; i++ {
-        if r.Name() == readers[i].Name() {
-            r.reader = readers[i]
-            if r.reader.IsCardPresent() {
-                return true
-            }
-        }
-    }
-    return false
+	count, err := r.context.client.SyncReaders()
+	if err != nil {
+		return false
+	}
+	readers := r.context.client.Readers()
+	for i := uint32(0); i < count; i++ {
+		if r.Name() == readers[i].Name() {
+			r.reader = readers[i]
+			if r.reader.IsCardPresent() {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (r *Reader) WaitUntilCardRemoved() {
-    for r.IsCardPresent() {
-        time.Sleep(250*time.Millisecond)
-    }
+	for r.IsCardPresent() {
+		time.Sleep(250 * time.Millisecond)
+	}
 }
 
 // Connect to card.
 func (r *Reader) Connect() (*Card, error) {
-    cardID, protocol, err := r.context.client.CardConnect(
-        r.context.ctxID, r.reader.Name())
-    if err != nil { return nil, err }
-    return &Card{
-        context: r.context,
-        cardID: cardID,
-        protocol: protocol,
-        atr: r.reader.CardAtr[:r.reader.CardAtrLength],
-    }, nil
+	cardID, protocol, err := r.context.client.CardConnect(
+		r.context.ctxID, r.reader.Name())
+	if err != nil {
+		return nil, err
+	}
+	return &Card{
+		context:  r.context,
+		cardID:   cardID,
+		protocol: protocol,
+		atr:      r.reader.CardAtr[:r.reader.CardAtrLength],
+	}, nil
 }
 
 // Smart card.
 type Card struct {
-    context *Context
-    cardID int32
-    protocol uint32
-    atr ATR
+	context  *Context
+	cardID   int32
+	protocol uint32
+	atr      ATR
 }
 
 // Return card ATR (answer to reset).
 func (c *Card) ATR() ATR {
-    return c.atr
+	return c.atr
 }
 
 // Trasmit bytes to card and return response.
 func (c *Card) Transmit(command []byte) ([]byte, error) {
-    response := make([]byte, 258)
-    received, err := c.context.client.Transmit(c.cardID, c.protocol,
-        command, response)
-    if err != nil { return nil, err }
-    return response[:received], nil
+	response := make([]byte, 258)
+	received, err := c.context.client.Transmit(c.cardID, c.protocol,
+		command, response)
+	if err != nil {
+		return nil, err
+	}
+	return response[:received], nil
 }
 
 // Disconnect from card.
 func (c *Card) Disconnect() error {
-    err := c.context.client.CardDisconnect(c.cardID)
-    if err != nil { return err }
-    return nil
+	err := c.context.client.CardDisconnect(c.cardID)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/smartcard/smartcard_winscard.go
+++ b/smartcard/smartcard_winscard.go
@@ -1,198 +1,217 @@
-// +build windows
+// +build windows darwin,cgo
 
 package smartcard
 
 import (
-    "fmt"
-    "time"
-    "github.com/sf1/go-card/smartcard/pcsc"
+	"fmt"
+	"github.com/sf1/go-card/smartcard/pcsc"
+	"time"
 )
 
 // A smart card context is required to access readers and cards.
 type Context struct {
-    ctxID uintptr
-    winscard *pcsc.WinscardWrapper
+	ctxID    uintptr
+	winscard *pcsc.WinscardWrapper
 }
 
 // Establish smart card context.
 // This should be the first function to be called.
 func EstablishContext() (*Context, error) {
-    winscard, err := pcsc.Winscard()
-    if err != nil {
-        return nil, err
-    }
-    ctxID, err := winscard.EstablishContext()
-    if err != nil { return nil, err }
-    return &Context{ctxID, winscard}, nil
+	winscard, err := pcsc.Winscard()
+	if err != nil {
+		return nil, err
+	}
+	ctxID, err := winscard.EstablishContext()
+	if err != nil {
+		return nil, err
+	}
+	return &Context{ctxID, winscard}, nil
 }
 
 // Release resources associated with smart card context.
 func (ctx *Context) Release() error {
-    return ctx.winscard.ReleaseContext(ctx.ctxID)
+	return ctx.winscard.ReleaseContext(ctx.ctxID)
 }
 
 // List all smart card readers.
 func (ctx *Context) ListReaders() ([]*Reader, error) {
-    readerNames, err := ctx.winscard.ListReaders(ctx.ctxID)
-    if err != nil { return nil, err }
-    readers := make([]*Reader, len(readerNames))
-    for i := 0; i < len(readerNames); i++ {
-        readers[i] = &Reader{context: ctx, name: readerNames[i]}
-    }
-    return readers, nil
+	readerNames, err := ctx.winscard.ListReaders(ctx.ctxID)
+	if err != nil {
+		return nil, err
+	}
+	readers := make([]*Reader, len(readerNames))
+	for i := 0; i < len(readerNames); i++ {
+		readers[i] = &Reader{context: ctx, name: readerNames[i]}
+	}
+	return readers, nil
 }
 
 // List smart card readers with inserted cards.
 func (ctx *Context) ListReadersWithCard() ([]*Reader, error) {
-    states, err := ctx.winscard.GetStatusChangeAll(
-        ctx.ctxID, pcsc.SCARD_INFINITE, pcsc.SCARD_STATE_UNAWARE)
-    if err != nil { return nil, err }
-    readers := make([]*Reader, 0, len(states))
-    for _, state := range states {
-        if state.EventState & pcsc.SCARD_STATE_MUTE != 0 {
-            continue
-        }
-        if state.EventState & pcsc.SCARD_STATE_PRESENT != 0 {
-            readers = append(readers, &Reader{context: ctx, name: state.Reader})
-        }
-    }
-    return readers, nil
+	states, err := ctx.winscard.GetStatusChangeAll(
+		ctx.ctxID, pcsc.SCARD_INFINITE, pcsc.SCARD_STATE_UNAWARE)
+	if err != nil {
+		return nil, err
+	}
+	readers := make([]*Reader, 0, len(states))
+	for _, state := range states {
+		if state.EventState&pcsc.SCARD_STATE_MUTE != 0 {
+			continue
+		}
+		if state.EventState&pcsc.SCARD_STATE_PRESENT != 0 {
+			readers = append(readers, &Reader{context: ctx, name: state.Reader})
+		}
+	}
+	return readers, nil
 }
 
 // Block until a smart card is inserted into any reader.
 // Returns immediately if card already present.
 func (ctx *Context) WaitForCardPresent() (*Reader, error) {
-    var err error
-    var reader *Reader = nil
-    var states []pcsc.ReaderState
-    for reader == nil {
-        states, err = ctx.winscard.GetStatusChangeAll(
-            ctx.ctxID, pcsc.SCARD_INFINITE, pcsc.SCARD_STATE_UNAWARE)
-        if err != nil { return nil, err }
-        if states == nil {
-            time.Sleep(500*time.Millisecond)
-            continue
-        }
-        for _, state := range states {
-            state.CurrentState = state.EventState
-            if state.EventState & pcsc.SCARD_STATE_MUTE != 0 {
-                continue
-            }
-            if state.EventState & pcsc.SCARD_STATE_PRESENT != 0 {
-                reader = &Reader{context: ctx, name: state.Reader}
-                break
-            }
-        }
-        if reader == nil {
-            err = ctx.winscard.GetStatusChange(
-                ctx.ctxID, pcsc.SCARD_INFINITE, states,
-            )
-            if err != nil { return nil, err }
-            time.Sleep(500*time.Millisecond)
-        }
-    }
-    return reader, nil
+	var err error
+	var reader *Reader = nil
+	var states []pcsc.ReaderState
+	for reader == nil {
+		states, err = ctx.winscard.GetStatusChangeAll(
+			ctx.ctxID, pcsc.SCARD_INFINITE, pcsc.SCARD_STATE_UNAWARE)
+		if err != nil {
+			return nil, err
+		}
+		if states == nil {
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+		for _, state := range states {
+			state.CurrentState = state.EventState
+			if state.EventState&pcsc.SCARD_STATE_MUTE != 0 {
+				continue
+			}
+			if state.EventState&pcsc.SCARD_STATE_PRESENT != 0 {
+				reader = &Reader{context: ctx, name: state.Reader}
+				break
+			}
+		}
+		if reader == nil {
+			err = ctx.winscard.GetStatusChange(
+				ctx.ctxID, pcsc.SCARD_INFINITE, states,
+			)
+			if err != nil {
+				return nil, err
+			}
+			time.Sleep(500 * time.Millisecond)
+		}
+	}
+	return reader, nil
 }
 
-// Smart card reader. 
+// Smart card reader.
 // Note that physical card readers with slots for multiple cards are
 // represented by one Reader instance per slot.
 type Reader struct {
-    context *Context
-    name string
+	context *Context
+	name    string
 }
 
 // Return name of card reader.
 func (r *Reader) Name() string {
-    return r.name
+	return r.name
 }
 
 // Check if card is present.
 func (r *Reader) IsCardPresent() bool {
-    states := make([]pcsc.ReaderState, 1)
-    states[0].Reader = r.name
-    states[0].CurrentState = pcsc.SCARD_STATE_UNAWARE
-    err := r.context.winscard.GetStatusChange(r.context.ctxID,
-        pcsc.SCARD_INFINITE, states)
-    if err != nil {
-        return false
-    }
-    if states[0].EventState & pcsc.SCARD_STATE_MUTE != 0 {
-        return false
-    }
-    return states[0].EventState & pcsc.SCARD_STATE_PRESENT != 0
+	states := make([]pcsc.ReaderState, 1)
+	states[0].Reader = r.name
+	states[0].CurrentState = pcsc.SCARD_STATE_UNAWARE
+	err := r.context.winscard.GetStatusChange(r.context.ctxID,
+		pcsc.SCARD_INFINITE, states)
+	if err != nil {
+		return false
+	}
+	if states[0].EventState&pcsc.SCARD_STATE_MUTE != 0 {
+		return false
+	}
+	return states[0].EventState&pcsc.SCARD_STATE_PRESENT != 0
 }
 
 // Wait until card removed
 func (r *Reader) WaitUntilCardRemoved() {
-    states := make([]pcsc.ReaderState, 1)
-    for {
-        states[0].Reader = r.name
-        states[0].CurrentState = pcsc.SCARD_STATE_UNAWARE
-        err := r.context.winscard.GetStatusChange(r.context.ctxID,
-            pcsc.SCARD_INFINITE, states)
-        if err != nil {
-            return
-        }
-        if states[0].EventState & pcsc.SCARD_STATE_MUTE != 0 ||
-            states[0].EventState & pcsc.SCARD_STATE_PRESENT == 0 {
-                return
-        }
-        time.Sleep(500*time.Millisecond)
-    }
+	states := make([]pcsc.ReaderState, 1)
+	for {
+		states[0].Reader = r.name
+		states[0].CurrentState = pcsc.SCARD_STATE_UNAWARE
+		err := r.context.winscard.GetStatusChange(r.context.ctxID,
+			pcsc.SCARD_INFINITE, states)
+		if err != nil {
+			return
+		}
+		if states[0].EventState&pcsc.SCARD_STATE_MUTE != 0 ||
+			states[0].EventState&pcsc.SCARD_STATE_PRESENT == 0 {
+			return
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
 }
-
 
 // Connect to card.
 func (r *Reader) Connect() (*Card, error) {
-    var pci uintptr
-    cardID, protocol, err := r.context.winscard.CardConnect(
-        r.context.ctxID, r.name)
-    if err != nil { return nil, err }
-    switch(protocol) {
-        case pcsc.SCARD_PROTOCOL_T0:
-            pci = r.context.winscard.T0PCI()
-        case pcsc.SCARD_PROTOCOL_T1:
-            pci = r.context.winscard.T1PCI()
-        default:
-            return nil, fmt.Errorf("Unknown protocol: %08x", protocol)
-    }
-    return &Card{
-        context:r.context, 
-        cardID: cardID,
-        sendPCI: pci, 
-    }, nil
+	var pci uintptr
+	cardID, protocol, err := r.context.winscard.CardConnect(
+		r.context.ctxID, r.name)
+	if err != nil {
+		return nil, err
+	}
+	switch protocol {
+	case pcsc.SCARD_PROTOCOL_T0:
+		pci = r.context.winscard.T0PCI()
+	case pcsc.SCARD_PROTOCOL_T1:
+		pci = r.context.winscard.T1PCI()
+	default:
+		return nil, fmt.Errorf("Unknown protocol: %08x", protocol)
+	}
+	return &Card{
+		context: r.context,
+		cardID:  cardID,
+		sendPCI: pci,
+	}, nil
 }
 
 // Smart card.
 type Card struct {
-    context *Context
-    cardID uintptr
-    sendPCI uintptr
-    atr ATR
+	context *Context
+	cardID  uintptr
+	sendPCI uintptr
+	atr     ATR
 }
 
 // Disconnect from card.
 func (c *Card) Disconnect() error {
-    err := c.context.winscard.CardDisconnect(c.cardID)
-    if err != nil { return err }
-    return nil
+	err := c.context.winscard.CardDisconnect(c.cardID)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // Return card ATR (answer to reset).
 func (c *Card) ATR() ATR {
-    var err error
-    if c.atr != nil { return c.atr }
-    c.atr, err = c.context.winscard.GetAttrib(c.cardID, pcsc.SCARD_ATTR_ATR_STRING)
-    if err != nil { return nil }
-    return c.atr
+	var err error
+	if c.atr != nil {
+		return c.atr
+	}
+	c.atr, err = c.context.winscard.GetAttrib(c.cardID, pcsc.SCARD_ATTR_ATR_STRING)
+	if err != nil {
+		return nil
+	}
+	return c.atr
 }
 
 // Trasmit bytes to card and return response.
 func (c *Card) Transmit(command []byte) ([]byte, error) {
-    response := make([]byte, 258)
-    received, err := c.context.winscard.Transmit(c.cardID, c.sendPCI,
-        command, response)
-    if err != nil { return nil, err }
-    return response[:received], nil
+	response := make([]byte, 258)
+	received, err := c.context.winscard.Transmit(c.cardID, c.sendPCI,
+		command, response)
+	if err != nil {
+		return nil, err
+	}
+	return response[:received], nil
 }


### PR DESCRIPTION
Hi, I was able to get go-card running on Mac OSX. Apple has an own implementation of PCSC-Lite which is not providing a unix socket. https://ludovicrousseau.blogspot.com/2014/03/differences-between-apple-pcsc-lite-and.html
Actually apple uses the winscard approach.
You would need CGO in order to get it running. It works on my machine and all the tests are passing.